### PR TITLE
Prevent brute force, credential stuffing and password spraying.

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -73,6 +73,9 @@ services:
       FORWARD_PORT: 80
       REDIRECT_URL: /
       ENABLE_EMAIL_OTP: 'true'
+      ## Hcaptcha for throttleing - These are test keys
+      HCAPTCHA_SITE_KEY: '10000000-ffff-ffff-ffff-000000000001'
+      HCAPTCHA_SECRET_KEY: '0x0000000000000000000000000000000000000000'
 
     working_dir: /vscode
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,7 @@ dependencies = [
  "env_logger",
  "futures",
  "lettre",
+ "lru_time_cache",
  "markup",
  "rand 0.8.3",
  "regex",
@@ -1288,6 +1289,12 @@ checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
 ]
+
+[[package]]
+name = "lru_time_cache"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 
 [[package]]
 name = "maplit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ futures = "0.3"
 # For sending emails
 lettre = "0.10.0-rc.3"
 
+# Finger printing
+lru_time_cache = "0.11.11"
+
 [build-dependencies]
 sha1 = "0.6"  # Use by build.rs for cache busting.
 

--- a/src/auth/email_otp.rs
+++ b/src/auth/email_otp.rs
@@ -124,13 +124,12 @@ pub async fn process_otp(
             .await?;
 
             // If we have more than 1 attempt we need to apply the Hcaptcha
-            if db_session.otp_code_attempts > 0 {
-                if !super::verify_hcaptcha(&config.hcaptcha_config, &form.h_captcha_response).await
-                {
-                    return Ok(HttpResponse::SeeOther()
-                        .append_header((http::header::LOCATION, crate::EMAIL_OTP_URL))
-                        .finish());
-                }
+            if db_session.otp_code_attempts > 0
+                && !super::verify_hcaptcha(&config.hcaptcha_config, &form.h_captcha_response).await
+            {
+                return Ok(HttpResponse::SeeOther()
+                    .append_header((http::header::LOCATION, crate::EMAIL_OTP_URL))
+                    .finish());
             }
 
             if db_session.otp_code == form.code {

--- a/src/auth/email_otp.rs
+++ b/src/auth/email_otp.rs
@@ -18,9 +18,15 @@ pub struct Otp {
 
 #[derive(sqlx::FromRow, Debug)]
 pub struct Session {
+    user_id: i32,
     otp_code: i32,
     otp_code_attempts: i32,
     otp_code_sent: bool,
+}
+
+#[derive(sqlx::FromRow, Debug)]
+pub struct User {
+    email: String,
 }
 
 pub async fn email_otp(
@@ -32,11 +38,11 @@ pub async fn email_otp(
         if let Ok(uuid) = Uuid::parse_str(&session.session_uuid) {
             let db_session: Session = sqlx::query_as::<_, Session>(
                 "
-            SELECT otp_code, otp_code_attempts, otp_code_sent FROM sessions WHERE session_uuid = $1
+            SELECT user_id, otp_code, otp_code_attempts, otp_code_sent FROM sessions WHERE session_uuid = $1
             ",
             )
             .bind(uuid)
-            .fetch_one(pool.get_ref()) // -> Vec<Person>
+            .fetch_one(pool.get_ref())
             .await?;
 
             if !db_session.otp_code_sent {
@@ -50,9 +56,19 @@ pub async fn email_otp(
                 .await?;
 
                 if let Some(smtp_config) = &config.smtp_config {
+                    let db_user: User = sqlx::query_as::<_, User>(&format!(
+                        "
+                        SELECT email FROM {} WHERE id = $1
+                        ",
+                        config.user_table_name
+                    ))
+                    .bind(db_session.user_id)
+                    .fetch_one(pool.get_ref())
+                    .await?;
+
                     let email = Message::builder()
                         .from(smtp_config.from_email.clone())
-                        .to("ian.purton@gmail.com".parse().unwrap())
+                        .to(db_user.email.parse().unwrap())
                         .subject("Your confirmation code")
                         .body(
                             format!(
@@ -69,15 +85,25 @@ pub async fn email_otp(
                     crate::email::send_email(&config, email)
                 }
             }
+
+            let body = OtpPage {
+                form: &Otp::default(),
+                hcaptcha: db_session.otp_code_attempts > 0,
+                hcaptcha_config: &config.hcaptcha_config,
+                errors: &ValidationErrors::default(),
+            };
+
+            return Ok(layouts::session_layout(
+                "Confirmation Code",
+                &body.to_string(),
+            ));
         }
     }
 
-    let body = OtpPage {
-        form: &Otp::default(),
-        errors: &ValidationErrors::default(),
-    };
-
-    Ok(layouts::session_layout("Login", &body.to_string()))
+    // We shouldn't be here without a session. Go to sign in.
+    Ok(HttpResponse::SeeOther()
+        .append_header((http::header::LOCATION, crate::SIGN_IN_URL))
+        .finish())
 }
 
 pub async fn process_otp(
@@ -88,43 +114,51 @@ pub async fn process_otp(
 ) -> Result<HttpResponse, CustomError> {
     if let Some(session) = session {
         if let Ok(uuid) = Uuid::parse_str(&session.session_uuid) {
-            if super::verify_hcaptcha(&config.hcaptcha_config, &form.h_captcha_response).await {
-                let db_session: Session = sqlx::query_as::<_, Session>(
-                    "
-                    SELECT otp_code, otp_code_attempts, otp_code_sent FROM sessions WHERE session_uuid = $1
-                    ",
-                )
-                .bind(uuid)
-                .fetch_one(pool.get_ref()) // -> Vec<Person>
-                .await?;
+            let db_session: Session = sqlx::query_as::<_, Session>(
+                "
+                SELECT user_id, otp_code, otp_code_attempts, otp_code_sent FROM sessions WHERE session_uuid = $1
+                ",
+            )
+            .bind(uuid)
+            .fetch_one(pool.get_ref()) // -> Vec<Person>
+            .await?;
 
-                if db_session.otp_code == form.code {
-                    sqlx::query(
-                        "
-                        UPDATE sessions SET otp_code_confirmed = true WHERE session_uuid = $1
-                        ",
-                    )
-                    .bind(uuid)
-                    .execute(pool.get_ref())
-                    .await?;
-
-                    return Ok(HttpResponse::SeeOther()
-                        .append_header((http::header::LOCATION, config.redirect_url.clone()))
-                        .finish());
-                } else {
-                    sqlx::query(
-                        "
-                        UPDATE sessions SET otp_code_attempts = otp_code_attempts + 1 WHERE session_uuid = $1
-                        "
-                    )
-                    .bind(uuid )
-                    .execute(pool.get_ref())
-                    .await?;
-
+            // If we have more than 1 attempt we need to apply the Hcaptcha
+            if db_session.otp_code_attempts > 0 {
+                if !super::verify_hcaptcha(&config.hcaptcha_config, &form.h_captcha_response).await
+                {
                     return Ok(HttpResponse::SeeOther()
                         .append_header((http::header::LOCATION, crate::EMAIL_OTP_URL))
                         .finish());
                 }
+            }
+
+            if db_session.otp_code == form.code {
+                sqlx::query(
+                    "
+                    UPDATE sessions SET otp_code_confirmed = true WHERE session_uuid = $1
+                    ",
+                )
+                .bind(uuid)
+                .execute(pool.get_ref())
+                .await?;
+
+                return Ok(HttpResponse::SeeOther()
+                    .append_header((http::header::LOCATION, config.redirect_url.clone()))
+                    .finish());
+            } else {
+                sqlx::query(
+                    "
+                    UPDATE sessions SET otp_code_attempts = otp_code_attempts + 1 WHERE session_uuid = $1
+                    "
+                )
+                .bind(uuid )
+                .execute(pool.get_ref())
+                .await?;
+
+                return Ok(HttpResponse::SeeOther()
+                    .append_header((http::header::LOCATION, crate::EMAIL_OTP_URL))
+                    .finish());
             }
         }
     }
@@ -135,15 +169,28 @@ pub async fn process_otp(
 }
 
 markup::define! {
-    OtpPage<'a>(form: &'a  Otp,
+    OtpPage<'a>(form: &'a  Otp, hcaptcha: bool,
+    hcaptcha_config: &'a Option<config::HCaptchaConfig>,
     errors: &'a ValidationErrors) {
         form.m_authentication[method = "post"] {
 
-            h1 { "Password Reset Request" }
+            h1 { "Enter your confirmation code" }
 
             @forms::NumberInput{ title: "Code", name: "code", value: &form.code.to_string(), help_text: "", errors }
 
+            @if let Some(hcaptcha_config) = hcaptcha_config {
+                @if *hcaptcha {
+                    div."h-captcha"["data-sitekey"=&hcaptcha_config.hcaptcha_site_key] {}
+                }
+            }
+
             button.a_button.success[type = "submit"] { "Submit Code" }
+        }
+
+        @if let Some(_) = hcaptcha_config {
+            @if *hcaptcha {
+                script[src="https://hcaptcha.com/1/api.js", async="async", defer="defer"] {}
+            }
         }
     }
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -47,13 +47,12 @@ pub async fn verify_hcaptcha(
     hcaptcha_config: &Option<config::HCaptchaConfig>,
     response: &Option<String>,
 ) -> bool {
-    dbg!(&hcaptcha_config);
     // If we are jkust testing ignore the hcaptcha.
     // It was causing issues in the browser testing.
     if let Some(hcaptcha) = hcaptcha_config {
-        if hcaptcha.hcaptcha_secret_key == "0x0000000000000000000000000000000000000000" {
-            return true;
-        }
+        //if hcaptcha.hcaptcha_secret_key == "0x0000000000000000000000000000000000000000" {
+        //    return true;
+        //}
 
         if let Some(resp) = response {
             let mut url = Url::parse("https://hcaptcha.com/siteverify").unwrap();

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -47,6 +47,7 @@ pub async fn verify_hcaptcha(
     hcaptcha_config: &Option<config::HCaptchaConfig>,
     response: &Option<String>,
 ) -> bool {
+    dbg!(&hcaptcha_config);
     // If we are jkust testing ignore the hcaptcha.
     // It was causing issues in the browser testing.
     if let Some(hcaptcha) = hcaptcha_config {

--- a/src/auth/registration.rs
+++ b/src/auth/registration.rs
@@ -1,6 +1,7 @@
 use crate::components::forms;
 use crate::config;
 use crate::custom_error::CustomError;
+use crate::fingerprint;
 use crate::layouts;
 use actix_identity::Identity;
 use actix_web::{http, web, HttpResponse, Result};
@@ -9,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use std::borrow::Cow;
 use std::default::Default;
+use std::sync::Mutex;
 use validator::{Validate, ValidationError, ValidationErrors};
 
 #[derive(Serialize, Validate, Deserialize, Default)]
@@ -23,9 +25,17 @@ pub struct Registration {
     pub h_captcha_response: Option<String>,
 }
 
-pub async fn registration(config: web::Data<config::Config>) -> Result<HttpResponse> {
+pub async fn registration(
+    config: web::Data<config::Config>,
+    req: actix_web::HttpRequest,
+    finger_print: web::Data<Mutex<fingerprint::FingerPrint>>,
+) -> Result<HttpResponse> {
+    let mut finger_print = finger_print.lock().unwrap();
+    let hit_rate = finger_print.add_request(req);
+
     let body = RegistrationPage {
         form: &Registration::default(),
+        hcaptcha: hit_rate > config.hit_rate,
         hcaptcha_config: &config.hcaptcha_config,
         errors: &ValidationErrors::default(),
     };
@@ -39,17 +49,28 @@ struct InsertedUser {
 }
 
 pub async fn process_registration(
+    req: actix_web::HttpRequest,
+    finger_print: web::Data<Mutex<fingerprint::FingerPrint>>,
     pool: web::Data<PgPool>,
     config: web::Data<config::Config>,
     form: web::Form<Registration>,
     identity: Identity,
 ) -> Result<HttpResponse, CustomError> {
+    let mut finger_print = finger_print.lock().unwrap();
+    let hit_rate = finger_print.add_request(req);
+
     let registration = Registration {
         email: form.email.clone(),
         ..Default::default()
     };
 
-    if super::verify_hcaptcha(&config.hcaptcha_config, &form.h_captcha_response).await {
+    let valid = if hit_rate > config.hit_rate {
+        super::verify_hcaptcha(&config.hcaptcha_config, &form.h_captcha_response).await
+    } else {
+        true
+    };
+
+    if valid {
         match form.validate() {
             Ok(_) => {
                 let hashed_password =
@@ -76,6 +97,7 @@ pub async fn process_registration(
             Err(validation_errors) => {
                 let body = RegistrationPage {
                     form: &registration,
+                    hcaptcha: hit_rate > config.hit_rate,
                     hcaptcha_config: &config.hcaptcha_config,
                     errors: &validation_errors,
                 };
@@ -99,6 +121,7 @@ pub async fn process_registration(
 
         let body = RegistrationPage {
             form: &registration,
+            hcaptcha: hit_rate > config.hit_rate,
             hcaptcha_config: &config.hcaptcha_config,
             errors: &validation_errors,
         };
@@ -109,6 +132,7 @@ pub async fn process_registration(
 
 markup::define! {
     RegistrationPage<'a>(form: &'a  Registration,
+        hcaptcha: bool,
         hcaptcha_config: &'a Option<config::HCaptchaConfig>,
         errors: &'a ValidationErrors) {
         form.m_authentication[method = "post"] {
@@ -117,8 +141,10 @@ markup::define! {
             @forms::PasswordInput{ title: "Password", name: "password", value: &form.password, help_text: "", errors }
             @forms::PasswordInput{ title: "Confirm Password", name: "confirm_password", value: &form.confirm_password, help_text: "", errors }
 
-            @if let Some(hcaptcha) = hcaptcha_config {
-                div."h-captcha"["data-sitekey"=&hcaptcha.hcaptcha_site_key] {}
+            @if let Some(hcaptcha_config) = hcaptcha_config {
+                @if *hcaptcha {
+                    div."h-captcha"["data-sitekey"=&hcaptcha_config.hcaptcha_site_key] {}
+                }
             }
 
             button.a_button.success[type = "submit"] { "Sign Up" }
@@ -126,7 +152,9 @@ markup::define! {
         }
 
         @if let Some(_) = hcaptcha_config {
-            script[src="https://hcaptcha.com/1/api.js", async="async", defer="defer"] {}
+            @if *hcaptcha {
+                script[src="https://hcaptcha.com/1/api.js", async="async", defer="defer"] {}
+            }
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,23 @@ pub struct HCaptchaConfig {
     pub hcaptcha_site_key: String,
 }
 
+impl HCaptchaConfig {
+    pub fn new() -> Option<HCaptchaConfig> {
+        if let Ok(hcaptcha_site_key) = env::var("HCAPTCHA_SITE_KEY") {
+            if let Ok(hcaptcha_secret_key) = env::var("HCAPTCHA_SECRET_KEY") {
+                Some(HCaptchaConfig {
+                    hcaptcha_secret_key,
+                    hcaptcha_site_key,
+                })
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct SmtpConfig {
     // Configure SMTP for email.
@@ -165,7 +182,7 @@ impl Config {
             secret_key: hex_to_bytes(&hex).expect("SECRET_KEY could not parse"),
             forward_url,
             skip_auth_for,
-            hcaptcha_config: None,
+            hcaptcha_config: HCaptchaConfig::new(),
             email_otp_enabled,
             smtp_config: SmtpConfig::new(),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,9 @@ pub struct Config {
 
     // Configure SMTP for email.
     pub smtp_config: Option<SmtpConfig>,
+
+    // How many hits oin a fingerprint before we show the captcha
+    pub hit_rate: u32,
 }
 
 impl Config {
@@ -185,6 +188,7 @@ impl Config {
             hcaptcha_config: HCaptchaConfig::new(),
             email_otp_enabled,
             smtp_config: SmtpConfig::new(),
+            hit_rate: 10,
         }
     }
 }

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -1,0 +1,34 @@
+use actix_web::HttpRequest;
+use lru_time_cache::LruCache;
+
+#[derive(Clone)]
+pub struct FingerPrint {
+    cache: LruCache<String, u32>,
+}
+
+impl FingerPrint {
+    pub fn new() -> FingerPrint {
+        let time_to_live = ::std::time::Duration::from_secs(60);
+        let lru_cache = LruCache::<String, u32>::with_expiry_duration(time_to_live);
+
+        FingerPrint { cache: lru_cache }
+    }
+
+    pub fn add_request(&mut self, req: HttpRequest) -> u32 {
+        if let Some(user_agent) = req.headers().get(actix_web::http::header::USER_AGENT) {
+            let user_agent = user_agent.to_str();
+
+            if let Ok(user_agent) = user_agent {
+                let count: u32 = if self.cache.get_mut(user_agent).is_some() {
+                    *self.cache.get_mut(user_agent).unwrap()
+                } else {
+                    0_u32
+                };
+                let count = count + 1;
+                self.cache.insert(user_agent.to_string(), count);
+                return count;
+            }
+        }
+        1000 // If no user agent erro force Captcha
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,12 @@ mod components;
 mod config;
 mod custom_error;
 mod email;
+mod fingerprint;
 mod layouts;
 use awc::Client;
 use custom_error::CustomError;
 use futures::future::{err, ok, Ready};
+use std::sync::Mutex;
 
 pub mod statics {
     include!(concat!(env!("OUT_DIR"), "/statics.rs"));
@@ -214,10 +216,13 @@ async fn main() -> io::Result<()> {
         encrypted_auth::routes
     };
 
+    let finger_print = web::Data::new(Mutex::new(fingerprint::FingerPrint::new()));
+
     HttpServer::new(move || {
         App::new()
             .data(db_pool.clone()) // pass database pool to application so we can access it inside handlers
             .data(config.clone())
+            .app_data(finger_print.clone())
             .data(Client::new())
             .service(statics::static_file)
             .configure(auth_routes)


### PR DESCRIPTION
If we show a captcha on login/registration if we are receiving a lot of login/registration requests from the same finger print.

If email OTP is enabled then any attack that still gets through needs access to the users email account anyway. 

Cache in memory of fixed window 1 minute. i..e key is IP + finger print  + window-> count for current window.

How to stop cache growing too large.

- [x] - Create finger print from headers IP Address? + header?
- [x] - Store in memory
- [x] - More than 1 request per 5 second then show captcha.
- [x] - OTP Code - show after 1 attempts
- [x] - Reset Password - Show always.
- [x] Conf codes are hard coded for ianxxxxx@gmail.com

Attack | Description
-- | --
Brute Force | Testing multiple passwords from dictionary or other source against a single account.
Credential Stuffing | Testing username/password pairs obtained from the breach of another site.
Password Spraying | Testing a single weak password against a large number of different accounts.